### PR TITLE
Allow vmq plugin modules to refer [*_hook types] as remote types

### DIFF
--- a/src/auth_on_publish_hook.erl
+++ b/src/auth_on_publish_hook.erl
@@ -17,3 +17,5 @@
                                                       | {ok, Modifiers  :: [msg_modifier()]}
                                                       | {error, Reason  :: any()}
                                                       | next.
+
+-export_type([msg_modifier/0]).

--- a/src/auth_on_register_hook.erl
+++ b/src/auth_on_register_hook.erl
@@ -14,3 +14,5 @@
                                                            | {ok, [reg_modifiers()]}
                                                            | {error, invalid_credentials | any()}
                                                            | next.
+
+-export_type([reg_modifiers/0]).

--- a/src/on_config_change_hook.erl
+++ b/src/on_config_change_hook.erl
@@ -7,3 +7,5 @@
 
 %% called as an 'all'-hook, return value is ignored
 -callback change_config(AllConfig :: all_config()) -> any().
+
+-export_type([all_config/0, application_config/0, config_val/0]).

--- a/src/on_deliver_hook.erl
+++ b/src/on_deliver_hook.erl
@@ -10,3 +10,5 @@
                                                     | {ok, Payload    :: payload()}
                                                     | {ok, Modifiers  :: [msg_modifier()]}
                                                     | next.
+
+-export_type([msg_modifier/0]).


### PR DESCRIPTION
Hi there!

A module can export some types to declare that other modules are allowed to refer to them as remote types (`export_type`). It would be nice to allow vmq plugins to use `vmq_commons` hook type information for their own needs.

This type information can be used for the following:
- To document function interfaces explicitly
- To provide more information for bug detection tools, such as Dialyzer
- To be exploited by documentation tools, such as EDoc, for generating program documentation of various forms

What do you think about it? Many thanks in advance!
