### PR TITLE
on_offline_message/5

### DIFF
--- a/src/on_offline_message5_hook.erl
+++ b/src/on_offline_message5_hook.erl
@@ -2,8 +2,8 @@
 -include("vmq_types.hrl").
 
 %% called as an 'all'-hook, return value is ignored
--callback on_offline_message(SubscriberId  :: subscriber_id(),
-                             QoS           :: qos(),
-                             Topic         :: topic(),
-                             Payload       :: payload(),
-                             IsRetain      :: flag()) -> any().
+-callback on_offline_message5(SubscriberId  :: subscriber_id(),
+                              QoS           :: qos(),
+                              Topic         :: topic(),
+                              Payload       :: payload(),
+                              IsRetain      :: flag()) -> any().

--- a/src/on_offline_message5_hook.erl
+++ b/src/on_offline_message5_hook.erl
@@ -1,9 +1,0 @@
--module(on_offline_message5_hook).
--include("vmq_types.hrl").
-
-%% called as an 'all'-hook, return value is ignored
--callback on_offline_message5(SubscriberId  :: subscriber_id(),
-                              QoS           :: qos(),
-                              Topic         :: topic(),
-                              Payload       :: payload(),
-                              IsRetain      :: flag()) -> any().

--- a/src/on_offline_message5_hook.erl
+++ b/src/on_offline_message5_hook.erl
@@ -1,0 +1,9 @@
+-module(on_offline_message5_hook).
+-include("vmq_types.hrl").
+
+%% called as an 'all'-hook, return value is ignored
+-callback on_offline_message(SubscriberId  :: subscriber_id(),
+                             QoS           :: qos(),
+                             Topic         :: topic(),
+                             Payload       :: payload(),
+                             IsRetain      :: flag()) -> any().

--- a/src/on_offline_message_hook.erl
+++ b/src/on_offline_message_hook.erl
@@ -2,4 +2,8 @@
 -include("vmq_types.hrl").
 
 %% called as an 'all'-hook, return value is ignored
--callback on_offline_message(SubscriberId  :: subscriber_id()) -> any().
+-callback on_offline_message(SubscriberId  :: subscriber_id(),
+                             QoS           :: qos(),
+                             Topic         :: topic(),
+                             Payload       :: payload(),
+                             IsRetain      :: flag()) -> any().

--- a/src/on_offline_message_hook.erl
+++ b/src/on_offline_message_hook.erl
@@ -2,4 +2,4 @@
 -include("vmq_types.hrl").
 
 %% called as an 'all'-hook, return value is ignored
--callback on_offline_message(SubscriberId  :: subscriber_id(), What :: any()) -> any().
+-callback on_offline_message(SubscriberId  :: subscriber_id()) -> any().

--- a/src/on_offline_message_hook.erl
+++ b/src/on_offline_message_hook.erl
@@ -2,4 +2,4 @@
 -include("vmq_types.hrl").
 
 %% called as an 'all'-hook, return value is ignored
--callback on_offline_message(SubscriberId  :: subscriber_id()) -> any().
+-callback on_offline_message(SubscriberId  :: subscriber_id(), What :: any()) -> any().


### PR DESCRIPTION
Hi!
In my plugin:
```
on_offline_message5({_MountPoint, ClientId}, QoS, Topic, Payload, IsRetain) ->
    apns:send_message(apns, ClientId, Payload),
    %%Or Google Fcm Gcm
    ok.
```
I can handle the message with apple apns or google fcm when the client disconnected.

vmq_server: https://github.com/erlio/vmq_server/pull/116